### PR TITLE
feat: Create Sign In page

### DIFF
--- a/pages/home/[[...index]].js
+++ b/pages/home/[[...index]].js
@@ -1,18 +1,27 @@
 import Link from 'next/link';
+import { useRouter } from 'next/router';
 import styles from '/styles/Home.module.css';
 
 const Home = () => {
+  const { query } = useRouter();
+  const strategy = query?.strategy || 'email_link';
   const features = [
     {
       name: 'Passwords',
+      label: 'Password',
+      strategy: 'password',
       path: '/passwords'
     },
     {
       name: 'One-Time Passcodes',
+      label: 'One-Time Passcode',
+      strategy: 'email_code',
       path: '#otp'
     },
     {
       name: 'Magic Links',
+      label: 'Email Magic Link',
+      strategy: 'email_link',
       path: '#magic-links'
     },
     {
@@ -28,14 +37,15 @@ const Home = () => {
       path: '#profile'
     }
   ];
+  const link = features.find((f) => f.strategy === strategy);
 
   return (
     <div className={styles.container}>
       <h1 className={styles.title}>Clerk Playground</h1>
       <p>
-        You've just signed in with an{' '}
-        <Link href="#magic-link">
-          <a className={styles.link}>Email Magic Link</a>
+        You've just signed in with{' '}
+        <Link href={link.path}>
+          <a className={styles.link}>{link.label}</a>
         </Link>
         . Choose another feature of Clerk to explore:
       </p>

--- a/pages/sign-in/[[...index]].js
+++ b/pages/sign-in/[[...index]].js
@@ -1,12 +1,209 @@
-import { SignIn } from '@clerk/nextjs';
+import { SignIn, useSignIn } from '@clerk/nextjs';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
-const SignInPage = () => (
-  <SignIn
-    path="/sign-in"
-    routing="path"
-    signUpUrl="/sign-up"
-    afterSignInUrl="/home"
-  />
-);
+import common from '/styles/Common.module.css';
+import styles from '/styles/SignIn.module.css';
+
+const SignInPage = () => {
+  const { signIn, setSession } = useSignIn();
+  const router = useRouter();
+  const [strategy, setStrategy] = useState('');
+  const [status, setStatus] = useState('');
+  const getButtonText = () => {
+    if (!status && strategy !== 'password') {
+      return 'Continue';
+    }
+
+    if (strategy === 'email_link' && status) {
+      return 'Resend link';
+    }
+
+    return 'Sign in';
+  };
+
+  const signInWithLink = async (strategy, status, formData) => {
+    const firstFactor = signIn.supportedFirstFactors.find(
+      (f) => f.strategy === strategy
+    );
+    const { emailAddressId } = firstFactor;
+    const { startMagicLinkFlow, cancelMagicLinkFlow } =
+      signIn.createMagicLinkFlow();
+
+    const response = await startMagicLinkFlow({
+      emailAddressId,
+      redirectUrl: `${window.location.origin}/home?strategy=${strategy}`
+    });
+
+    const verification = response.firstFactorVerification;
+
+    if (verification.status === 'expired') {
+      // TODO: Handle expired links
+    }
+
+    await cancelMagicLinkFlow();
+    if (response.status === 'complete') {
+      setSession(response.createdSessionId, () =>
+        router.push(`/home?strategy=${strategy}`)
+      );
+      return;
+    }
+  };
+
+  const signInWithCode = async (strategy, status, formData) => {
+    const code = formData.get('code');
+
+    if (status !== 'needs_first_factor') {
+      return;
+    }
+
+    try {
+      const response = await signIn.attemptFirstFactor({
+        strategy,
+        code
+      });
+
+      if (response.status === 'complete') {
+        setSession(response.createdSessionId, () =>
+          router.push(`/home?strategy=${strategy}`)
+        );
+      }
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  const handleSubmit = async (event) => {
+    const formData = new FormData(event.target);
+    const strategy = formData.get('strategy');
+    const identifier = formData.get('email');
+    const password = formData.get('password');
+
+    event.preventDefault();
+
+    if (!status) {
+      // Prepare sign in with strategy and identifier
+      const response = await signIn.create({
+        strategy,
+        identifier,
+        password: password || undefined,
+        redirect_url: `${window.location.origin}/home?strategy=${strategy}`
+      });
+
+      setStatus(response.status);
+
+      if (response.status === 'complete') {
+        setSession(response.createdSessionId, () =>
+          router.push(`/home?strategy=${strategy}`)
+        );
+      }
+
+      return;
+    }
+
+    // Attempt sign in with applicable strategy
+    if (strategy === 'email_link') {
+      return signInWithLink(strategy, status, formData);
+    }
+
+    if (strategy === 'email_code') {
+      return signInWithCode(strategy, status, formData);
+    }
+  };
+
+  return (
+    <div className={common.container}>
+      <h1>Welcome back to Clerk Playground!</h1>
+      <p>Been here before? Sign in using the form below.</p>
+      <p>
+        If it's your first time, you'll want to{' '}
+        <Link href="/sign-up">
+          <a className={common.link}>sign up</a>
+        </Link>{' '}
+        instead.
+      </p>
+      <form onSubmit={handleSubmit}>
+        <div className={styles.field}>
+          <label htmlFor="emailAddress">Email address</label>
+          <input
+            id="emailAddress"
+            name="email"
+            type="email"
+            placeholder="you@company.com"
+            required
+          />
+        </div>
+        <fieldset className={styles.field}>
+          <legend>How would you like to sign in?</legend>
+          <div className={styles.field}>
+            <input
+              type="radio"
+              id="magicLink"
+              name="strategy"
+              onChange={(e) => setStrategy(e.target.value)}
+              value="email_link"
+              required
+            />
+            <label htmlFor="magicLink">Magic link</label>
+          </div>
+          <div className={styles.field}>
+            <input
+              type="radio"
+              id="passcode"
+              name="strategy"
+              onChange={(e) => setStrategy(e.target.value)}
+              value="email_code"
+              required
+            />
+            <label htmlFor="passcode">One-time passcode</label>
+          </div>
+          <div className={styles.field}>
+            <input
+              type="radio"
+              id="password"
+              name="strategy"
+              onChange={(e) => setStrategy(e.target.value)}
+              value="password"
+              required
+            />
+            <label htmlFor="password">Password</label>
+          </div>
+        </fieldset>
+        {strategy === 'email_code' && status === 'needs_first_factor' ? (
+          <div className={styles.field}>
+            <label>Verfication code</label>
+            <input
+              type="text"
+              name="code"
+              placeholder="Code from email"
+              required
+            />
+          </div>
+        ) : null}
+        {strategy === 'password' ? (
+          <div className={styles.field}>
+            <label>Password</label>
+            <input
+              type="password"
+              name="password"
+              placeholder="Your password"
+              required
+            />
+          </div>
+        ) : null}
+        {strategy === 'email_link' && status === 'needs_first_factor' ? (
+          <div className={styles.message}>
+            Check your email inbox for a sign in link. It will expire in 10
+            minutes.
+          </div>
+        ) : null}
+        <button className={common.button} type="submit">
+          {getButtonText()}
+        </button>
+      </form>
+    </div>
+  );
+};
 
 export default SignInPage;

--- a/styles/SignIn.module.css
+++ b/styles/SignIn.module.css
@@ -1,0 +1,31 @@
+.field {
+  margin: 24px 0 16px;
+}
+
+.field > label,
+.field > input {
+  font-family: 'Source Sans Pro', sans-serif;
+  font-size: 18px;
+}
+
+.field > label {
+  display: inline-block;
+  min-width: 150px;
+  margin-right: 16px;
+  font-weight: 600;
+}
+
+.field > input {
+  padding: 2px 6px;
+}
+
+.message {
+  margin: 24px 0;
+  width: 500px;
+  min-height: 36px;
+  opacity: 1;
+  background-color: rgb(167, 255, 177, 0.5);
+  border-radius: 2px;
+  padding: 8px 16px;
+  transition: all 0.6s ease;
+}


### PR DESCRIPTION
Resolves #5 

Created custom Sign In page. It currently supports the following:

- Magic links
- One-time passcode (email)
- Password

Eventually, we will add OAuth and SMS options.

![Sign in](https://user-images.githubusercontent.com/97047001/175143356-23716d7a-9e4a-45fa-981e-11bbc63c1c6d.png)

The only thing I wasn't sure how to do when using magic links is to make the initial page say something like "Signed in on another tab" as we do with the Clerk hosted pages.

I also created a `Common.module.css` file for shared styles so we can avoid some duplication.